### PR TITLE
Rename former repository references

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Ansible Keylime
 
 [![Build Status](https://travis-ci.org/keylime/ansible-keylime-soft-tpm.svg?branch=master)](https://travis-ci.org/keylime/ansible-keylime-soft-tpm) [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/keylime-project/community)
 
-Ansible role to deploy [Python Keylime](https://github.com/keylime/python-keylime) and a TPM Emulator,
+Ansible role to deploy [Keylime](https://github.com/keylime/keylime) and a TPM Emulator,
 alongside the  [Keylime rust cloud node](https://github.com/keylime/rust-keylime)
 on Fedora release 29.
 

--- a/roles/ansible-keylime-tpm12/tasks/git-repos.yml
+++ b/roles/ansible-keylime-tpm12/tasks/git-repos.yml
@@ -1,7 +1,7 @@
-- name: Clone python-keylime
+- name: Clone keylime
   git:
-    repo: https://github.com/mit-ll/python-keylime
-    dest: /root/python-keylime
+    repo: https://github.com/mit-ll/keylime
+    dest: /root/keylime
 
 - name: Clone tpm4720-keylime
   git:

--- a/roles/ansible-keylime-tpm12/tasks/keylime.yml
+++ b/roles/ansible-keylime-tpm12/tasks/keylime.yml
@@ -1,11 +1,11 @@
 - name: Run python setup tools to install Keylime
   shell: "/usr/bin/python2.7 setup.py install"
   args:
-    chdir: /root/python-keylime
+    chdir: /root/keylime
 
 - name: Move keylime.conf into default location
   copy:
-    src: /root/python-keylime/keylime.conf
+    src: /root/keylime/keylime.conf
     dest: /etc
     mode: 0644
     remote_src: yes

--- a/roles/ansible-keylime-tpm12/tasks/main.yml
+++ b/roles/ansible-keylime-tpm12/tasks/main.yml
@@ -4,5 +4,5 @@
 - include: packages.yml
 - include: git-repos.yml
 - include: ibm-tpm.yml
-- include: python-keylime.yml
+- include: keylime.yml
 - include: rust-keylime.yml

--- a/roles/ansible-keylime-tpm20/tasks/git-repos.yml
+++ b/roles/ansible-keylime-tpm20/tasks/git-repos.yml
@@ -1,13 +1,13 @@
-- name: Clone python-keylime
+- name: Clone keylime
   git:
-    repo: https://github.com/keylime/python-keylime
-    dest: /root/python-keylime
+    repo: https://github.com/keylime/keylime
+    dest: /root/keylime
 
 - name: Clone tpm2 software stack
   git:
     repo: https://github.com/tpm2-software/tpm2-tss
     dest: /root/tpm2-tss
-    version: "{{ tpm2_tss_version }}" 
+    version: "{{ tpm2_tss_version }}"
 
 - name: Clone tpm2 tools
   git:

--- a/roles/ansible-keylime-tpm20/tasks/keylime.yml
+++ b/roles/ansible-keylime-tpm20/tasks/keylime.yml
@@ -1,16 +1,16 @@
 - name: remove openssl-devel package installation in the install.sh script
   lineinfile:
-      dest: /root/python-keylime/installer.sh
+      dest: /root/keylime/installer.sh
       regexp: 'openssl-devel'
       line: '    BUILD_TOOLS="libtool make automake pkg-config m4 libgcrypt-devel autoconf autoconf-archive libcurl-devel libstdc++-devel uriparser-devel dbus-devel gnulib-devel python2-pyyaml doxygen"'
 
 - name: remove openssl-devel package installation in the install.sh script
   lineinfile:
-      dest: /root/python-keylime/installer.sh
+      dest: /root/keylime/installer.sh
       regexp: 'openssl-devel'
-      line: '    PYTHON_DEPS="python2-pip gcc gcc-c++ swig"' 
+      line: '    PYTHON_DEPS="python2-pip gcc gcc-c++ swig"'
 
 - name: Run python setup tools to install Keylime
   command: ./installer.sh -smo
   args:
-    chdir: /root/python-keylime
+    chdir: /root/keylime

--- a/roles/ansible-keylime-tpm20/tasks/main.yml
+++ b/roles/ansible-keylime-tpm20/tasks/main.yml
@@ -4,5 +4,5 @@
 - include: git-repos.yml
 - include: tpm2-software.yml
 - include: ibm-tpm.yml
-- include: python-keylime.yml
+- include: keylime.yml
 - include: rust-keylime.yml


### PR DESCRIPTION
Inline with the agreed repo name change from python-keylime
to keylime, this PR makes the needed changes.